### PR TITLE
feat: Add eks handler

### DIFF
--- a/src/newnoise/sheet/commands.py
+++ b/src/newnoise/sheet/commands.py
@@ -6,6 +6,7 @@ HANDLERS = [
     handlers.EC2InstanceHandler(),
     handlers.EC2HostHandler(),
     handlers.LoadBalancerHandler(),
+    handlers.EKSHandler(),
     handlers.RDSInstanceHandler(),
     handlers.RDSIOPSHandler(),
     handlers.RDSStorageHandler(),

--- a/src/newnoise/sheet/handlers.py
+++ b/src/newnoise/sheet/handlers.py
@@ -149,6 +149,26 @@ class LoadBalancerHandler(AWSBaseHandler):
                 return "gateway"
         return attr
 
+class EKSHandler(AWSBaseHandler):
+    TF = "aws_eks_cluster"
+
+    def match(self, row):
+        return (
+            super().match(row)
+            and matchers.product_servicecode(row, v="AmazonEKS")
+            and matchers.product_usagetype(row, c="AmazonEKS-Hours:perCluster")
+        )
+
+    def process(self, row):
+        return process(
+            row,
+            {},
+            {},
+            a.priced_by_time,
+            service_provider="aws",
+            tf_resource=self.TF,
+            service_class=a.const("cluster"),
+        )
 
 class RDSBaseHandler(AWSBaseHandler):
     """


### PR DESCRIPTION
It will process the products.csv to generates prices lines such as:

```
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=ap-northeast-1&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=ap-southeast-4&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=eu-south-1&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=ap-southeast-2&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=eu-central-2&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=us-east-1&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=me-south-1&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD
AmazonEKS,Compute,type=aws_eks_cluster,end_usage_amount=Inf&purchase_option=on_demand&region=eu-west-1&service_class=cluster&service_provider=aws&start_usage_amount=0,0.1000000000,t,USD

```


Which can be fed to oiq for price processing